### PR TITLE
Add a prerequisite JIRA

### DIFF
--- a/sbbr/README.md
+++ b/sbbr/README.md
@@ -13,6 +13,7 @@ The SBBR test suites check for compliance against the SBBR specification. Like t
 
 ## UEFI Self Certification Tests
 Self Certification Tests (SCTs) test the UEFI implementation requirements defined by SBBR. The SCT implementation can eventually merge into the EDK2 tree and as a result, SBBR tests in these deliverables leverage those present in EDK2.
+**Prequisite** : NTP Sync should be done before running SCT
 
 ### Running SCT
 SBBR SCT tests are available only if the test suite is built with UEFI-SCT. By Default, UEFI-SCT is not included in the test suite. <br />


### PR DESCRIPTION
Add a prerequisite for running SCT
JIRA : PJ03206-76 : QC-ACS1.6-SCT: GetTime_Func and SetTime_Func test failed due to NTP time