### PR TITLE
Fix the sbsa-acs-val build: test_p004.c no longer exists

### DIFF
--- a/sbsa/scripts/Makefile.val
+++ b/sbsa/scripts/Makefile.val
@@ -37,7 +37,6 @@ sbsa_acs_val-objs += $(VAL_SRC)/avs_status.o \
     $(TEST_POOL)/test_p001.o \
     $(TEST_POOL)/test_p002.o \
     $(TEST_POOL)/test_p003.o \
-    $(TEST_POOL)/test_p004.o \
     $(TEST_POOL)/test_p005.o \
     $(TEST_POOL)/test_p006.o \
     $(TEST_POOL)/test_p007.o \


### PR DESCRIPTION
The test_p004.c PCIe test has been removed from the sbsa-acs repo.
Remove it from Makefile.val.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>