### PR TITLE
Switch to the linux-acs repo on the arm gitlab instance

### DIFF
--- a/sbsa/scripts/setup.sh
+++ b/sbsa/scripts/setup.sh
@@ -21,7 +21,7 @@ LUVDIR=$PWD/luv
 rm -rf $SRCDIR
 
 git clone https://github.com/ARM-software/sbsa-acs.git src
-git clone git://linux-arm.org/linux-acs.git
+git clone https://git.gitlab.arm.com/linux-arm/linux-acs.git
 
 mv linux-acs/sbsa-acs-drv/files/platform/pal_linux $SRCDIR/platform/
 mv linux-acs/sbsa-acs-drv $SRCDIR

--- a/sdei/scripts/setup.sh
+++ b/sdei/scripts/setup.sh
@@ -20,7 +20,7 @@ SRCDIR=$PWD/sdei
 LUVDIR=$PWD/luv
 
 cd $SRCDIR 
-git clone git://linux-arm.org/linux-acs.git
+git clone https://git.gitlab.arm.com/linux-arm/linux-acs.git
 cp -r linux-acs/sdei-acs-drv .
 rm -rf linux-acs
 cd $TOPDIR


### PR DESCRIPTION
The linux-arm.org site appears to be down, and anyway is old and
doesn't support https. Switch to the copy of linux-acs on gitlab.arm.com

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>