### PR TITLE
Fix ShellSbsa and PXEBOOT builds

### DIFF
--- a/luvos/scripts/build.sh
+++ b/luvos/scripts/build.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 TOPDIR=`pwd`
 
 #This parameter can be set to 0 if luv-netboot image is not needed in full build

--- a/sbsa/patches/ShellSbsa.patch
+++ b/sbsa/patches/ShellSbsa.patch
@@ -137,9 +137,9 @@ index 9429d6f4ea..242a4c921a 100644
    Pause.c
    GetMtc.c
    Help.c
-+  test_pool/secure/test_s001.c
-+  test_pool/secure/test_s002.c
-+  test_pool/secure/test_s003.c
++  #test_pool/secure/test_s001.c
++  #test_pool/secure/test_s002.c
++  #test_pool/secure/test_s003.c
 +  test_pool/pe/test_c001.c
 +  test_pool/pe/test_c002.c
 +  test_pool/pe/test_c003.c
@@ -176,8 +176,6 @@ index 9429d6f4ea..242a4c921a 100644
 +  test_pool/pe/test_c034.c
 +  test_pool/pe/test_c035.c
 +  test_pool/pe/test_c036.c
-+  test_pool/pe/test_c037.c
-+  test_pool/pe/test_c038.c
 +  test_pool/gic/test_g001.c
 +  test_pool/gic/test_g002.c
 +  test_pool/gic/test_g003.c
@@ -275,7 +273,7 @@ index 9429d6f4ea..242a4c921a 100644
  
  
  [Packages]
-@@ -55,6 +191,8 @@
+@@ -55,6 +189,8 @@
    HiiLib
    FileHandleLib
    HandleParsingLib


### PR DESCRIPTION
When building ShellSbsa, the files in test_pool/secure don't compile,
and test_pool/pe/test_c037.c and test_c038.c no longer exist.

Fix ShellSbsa.patch and add `set -e` to luvos/scripts/build.sh to
ensure any future problems cause the build to bail out instead of
silently breaking.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>