### PR TITLE
Allow acs_sync.sh and luvos/scripts/build.sh to be run non-interactively

### DIFF
--- a/acs_sync.sh
+++ b/acs_sync.sh
@@ -41,24 +41,26 @@ if [ $# -gt 0 ]; then
     validate_param $*
 fi
 
-./check_deps.sh
-if [ $? != 0 ]
-then
-    echo -e "\nDependencies have not been met to successfully download the software."
-    echo -e "\nWould you like to install the dependencies? [Y/N]"
-    read input
-    INSTALL=${input^^}
-    if [ "${INSTALL}" == "Y" ]
+if [ -n "$TERM" ] && [ "$TERM" != "dumb" ]; then
+    ./check_deps.sh
+    if [ $? != 0 ]
     then
-        echo -e "Installing dependencies."
-        sudo ./check_deps.sh -ip
-        if [ $? != 0 ]
+        echo -e "\nDependencies have not been met to successfully download the software."
+        echo -e "\nWould you like to install the dependencies? [Y/N]"
+        read input
+        INSTALL=${input^^}
+        if [ "${INSTALL}" == "Y" ]
         then
-            echo -e "$(tput setaf 1)Dependencies install failed. Exiting.$(tput sgr 0)"
+            echo -e "Installing dependencies."
+            sudo ./check_deps.sh -ip
+            if [ $? != 0 ]
+            then
+                echo -e "$(tput setaf 1)Dependencies install failed. Exiting.$(tput sgr 0)"
+                exit
+            fi
+        else
             exit
         fi
-    else
-        exit
     fi
 fi
 

--- a/luvos/scripts/build.sh
+++ b/luvos/scripts/build.sh
@@ -160,10 +160,12 @@ fi
 echo "Building LuvOS Image with SBBR and SBSA for AARCH64 ..."
 echo ""
 echo "Default kernel command line parameters: 'systemd.log_target=null plymouth.ignore-serial-consoles debug ip=dhcp log_buf_len=1M efi=debug acpi=on crashkernel=256M earlycon uefi_debug'"
-echo -n "Append parameters (press Enter for default):"
-read ACS_CMDLINE_APPEND
-export ACS_CMDLINE_APPEND
-export BB_ENV_EXTRAWHITE="BB_ENV_EXTRAWHITE ACS_CMDLINE_APPEND"
+if [ -n "$TERM" ] && [ "$TERM" != "dumb" ]; then
+	echo -n "Append parameters (press Enter for default):"
+	read ACS_CMDLINE_APPEND
+	export ACS_CMDLINE_APPEND
+	export BB_ENV_EXTRAWHITE="BB_ENV_EXTRAWHITE ACS_CMDLINE_APPEND"
+fi
 
 if [ $NUMOFARGS -gt 0 ]; then
 	if [ $NUMOFARGS -eq 1 ]; then


### PR DESCRIPTION
Check for the terminal type before running commands that check for
user input, and skip them if $TERM is empty or set to "dumb". This
allows acs_sync.sh and luvos/scripts/build.sh to be run in a script,
non-interatively.

Signed-off-by: Rebecca Cran <rebecca@nuviainc.com>